### PR TITLE
Support spotify chromium

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
+use crate::service_config::Service;
+
 #[derive(clap::StructOpt)]
 #[clap(version)]
 pub struct Opts {
     pub output_dir: Option<PathBuf>,
-    pub service_name: Option<String>,
+    pub service: Option<Service>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub static WAIT_TIME_BEFORE_FIRST_SONG: f64 = 1.0;
 pub static TIME_AFTER_SESSION_END: f64 = 10.0;
 
 pub static TIME_WITHOUT_DBUS_SIGNAL_BEFORE_STOPPING: Duration = Duration::from_secs(10);
+pub static TIME_BETWEEN_SUBSEQUENT_DBUS_COMMANDS: Duration = Duration::from_secs(1);
 
 pub static BITRATE: i64 = 192000;
 pub static MIN_OFFSET: f64 = -3.;

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,9 @@ pub static DEFAULT_MUSIC_DIR: &str = "music";
 
 pub static DEFAULT_SERVICE: &str = "spotify";
 // This should be more than 3-4 seconds at least
-pub static TIME_BEFORE_SESSION_START: f64 = 5.0;
-pub static WAIT_TIME_BEFORE_FIRST_SONG: f64 = 1.0;
-pub static TIME_AFTER_SESSION_END: f64 = 10.0;
+pub static TIME_BEFORE_SESSION_START: Duration = Duration::from_secs(5);
+pub static WAIT_TIME_BEFORE_FIRST_SONG: Duration = Duration::from_secs(1);
+pub static TIME_AFTER_SESSION_END: Duration = Duration::from_secs(10);
 
 pub static TIME_WITHOUT_DBUS_SIGNAL_BEFORE_STOPPING: Duration = Duration::from_secs(10);
 pub static TIME_BETWEEN_SUBSEQUENT_DBUS_COMMANDS: Duration = Duration::from_secs(1);

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub static TIME_BEFORE_SESSION_START: f64 = 5.0;
 pub static WAIT_TIME_BEFORE_FIRST_SONG: f64 = 1.0;
 pub static TIME_AFTER_SESSION_END: f64 = 10.0;
 
+pub static TIME_WITHOUT_DBUS_SIGNAL_BEFORE_STOPPING: Duration = Duration::from_secs(10);
+
 pub static BITRATE: i64 = 192000;
 pub static MIN_OFFSET: f64 = -3.;
 pub static MAX_OFFSET: f64 = 3.;

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -6,13 +6,14 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use serde::Deserialize;
-use serde::Serialize;
 
 use crate::config;
+use crate::service_config::Service;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct ConfigFile {
     pub output_dir: PathBuf,
+    pub service: Option<Service>,
 }
 
 impl ConfigFile {

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -151,7 +151,8 @@ pub fn cut_song(info: &CutInfo) -> Result<()> {
         info.song,
         target_file.to_str().unwrap()
     );
-    let out = Command::new("ffmpeg")
+    let mut command = Command::new("ffmpeg");
+    command
         .arg("-ss")
         .arg(format!("{}", info.start_time.time))
         .arg("-t")
@@ -169,9 +170,13 @@ pub fn cut_song(info: &CutInfo) -> Result<()> {
         .arg("-metadata")
         .arg(format!("artist={}", &info.song.artist))
         .arg("-metadata")
-        .arg(format!("albumartist={}", &info.song.artist))
-        .arg("-metadata")
-        .arg(format!("track={}", &info.song.track_number))
+        .arg(format!("albumartist={}", &info.song.artist));
+    if let Some(track_number) = info.song.track_number {
+        command
+            .arg("-metadata")
+            .arg(format!("track={}", track_number));
+    }
+    let out = command
         .arg("-y")
         .arg(target_file.to_str().unwrap())
         .output();

--- a/src/cut.rs
+++ b/src/cut.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::fs::create_dir_all;
 use std::path::Path;
 use std::path::PathBuf;
@@ -25,6 +26,7 @@ pub struct CutInfo {
     music_dir: PathBuf,
     start_time: AudioTime,
     end_time: AudioTime,
+    num_in_recording: usize,
 }
 
 impl CutInfo {
@@ -33,6 +35,7 @@ impl CutInfo {
         song: Song,
         start_time: AudioTime,
         end_time: AudioTime,
+        num_in_recording: usize,
     ) -> Self {
         let buffer_file = session.get_buffer_file();
         let music_dir = session.get_music_dir();
@@ -42,6 +45,7 @@ impl CutInfo {
             music_dir,
             start_time,
             end_time,
+            num_in_recording,
         }
     }
 }
@@ -139,9 +143,21 @@ fn get_all_valid_excerpts_and_songs(session: &RecordingSession) -> (Vec<AudioExc
     (audio_excerpts, valid_songs)
 }
 
+fn add_metadata_arg_if_present<T: Display>(
+    command: &mut Command,
+    get_str: fn(&T) -> String,
+    val: Option<&T>,
+) {
+    if let Some(val) = val {
+        command.arg("-metadata").arg(get_str(&val));
+    }
+}
+
 pub fn cut_song(info: &CutInfo) -> Result<()> {
     let difference = info.end_time.time - info.start_time.time;
-    let target_file = info.song.get_target_file(&info.music_dir);
+    let target_file = info
+        .song
+        .get_target_file(&info.music_dir, info.num_in_recording);
     create_dir_all(target_file.parent().unwrap())
         .context("Failed to create subfolders of target file")?;
     println!(
@@ -162,26 +178,38 @@ pub fn cut_song(info: &CutInfo) -> Result<()> {
         .arg("-c:a")
         .arg("libopus")
         .arg("-b:a")
-        .arg(format!("{}", config::BITRATE))
-        .arg("-metadata")
-        .arg(format!("title={}", &info.song.title))
-        .arg("-metadata")
-        .arg(format!("album={}", &info.song.album))
-        .arg("-metadata")
-        .arg(format!("artist={}", &info.song.artist))
-        .arg("-metadata")
-        .arg(format!("albumartist={}", &info.song.artist));
-    if let Some(track_number) = info.song.track_number {
-        command
-            .arg("-metadata")
-            .arg(format!("track={}", track_number));
-    }
+        .arg(format!("{}", config::BITRATE));
+    add_metadata_arg_if_present(
+        &mut command,
+        |title| format!("title={}", title),
+        info.song.title.as_ref(),
+    );
+    add_metadata_arg_if_present(
+        &mut command,
+        |album| format!("album={}", album),
+        info.song.album.as_ref(),
+    );
+    add_metadata_arg_if_present(
+        &mut command,
+        |artist| format!("artist={}", artist),
+        info.song.artist.as_ref(),
+    );
+    add_metadata_arg_if_present(
+        &mut command,
+        |artist| format!("albumartist={}", artist),
+        info.song.artist.as_ref(),
+    );
+    add_metadata_arg_if_present(
+        &mut command,
+        |track_number| format!("track={}", track_number),
+        info.song.track_number.as_ref(),
+    );
     let out = command
         .arg("-y")
         .arg(target_file.to_str().unwrap())
         .output();
     out.map(|_| ()).context(format!(
-        "Failed to cut song: {} {} {} ({}+{}) (is ffmpeg installed?)",
+        "Failed to cut song: {:?} {:?} {:?} ({:?}+{:?}) (is ffmpeg installed?)",
         &info.song.title, &info.song.album, &info.song.artist, info.start_time.time, difference,
     ))
 }

--- a/src/excerpt_collection.rs
+++ b/src/excerpt_collection.rs
@@ -29,7 +29,7 @@ impl ExcerptCollection {
     pub fn name(&self) -> String {
         let first_song = self.session.songs.first();
         match first_song {
-            Some(first_song) => format!("{} - {}", first_song.artist, first_song.album),
+            Some(first_song) => format!("{:?} - {:?}", first_song.artist, first_song.album),
             None => "".into(),
         }
     }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -27,11 +27,11 @@ use self::plot::ExcerptPlot;
 use crate::audio_time::AudioTime;
 use crate::cut::CutInfo;
 use crate::excerpt_collection::ExcerptCollection;
-use crate::get_service_name;
 use crate::gui::session_manager::SessionIdentifier;
 use crate::gui::session_manager::SessionManager;
 use crate::recording::recording_thread_handle_status::RecordingThreadHandleStatus;
 use crate::run_args::RunArgs;
+use crate::service_config::Service;
 use crate::service_config::ServiceConfig;
 use crate::song::format_title;
 use crate::song::Song;
@@ -42,7 +42,7 @@ struct SongIdentifier {
 }
 
 pub struct StriputaryGui {
-    service_name: Option<String>,
+    service: Service,
     collection: Option<ExcerptCollection>,
     plots: Vec<ExcerptPlot>,
     scroll_position: usize,
@@ -55,10 +55,10 @@ pub struct StriputaryGui {
 }
 
 impl StriputaryGui {
-    pub fn new(dir: &Path, service_name: Option<String>) -> Self {
+    pub fn new(dir: &Path, service: Service) -> Self {
         let session_manager = SessionManager::new(dir);
         let mut gui = Self {
-            service_name,
+            service,
             collection: None,
             plots: vec![],
             scroll_position: 0,
@@ -133,8 +133,7 @@ impl StriputaryGui {
     }
 
     fn get_run_args(&self) -> Option<RunArgs> {
-        let service_config =
-            ServiceConfig::from_service_name(&get_service_name(&self.service_name)).unwrap();
+        let service_config = ServiceConfig::from_service(self.service).unwrap();
         Some(RunArgs {
             session_dir: self.session_manager.get_currently_selected()?,
             service_config: service_config.clone(),

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -33,6 +33,7 @@ use crate::gui::session_manager::SessionManager;
 use crate::recording::recording_thread_handle_status::RecordingThreadHandleStatus;
 use crate::run_args::RunArgs;
 use crate::service_config::ServiceConfig;
+use crate::song::format_title;
 use crate::song::Song;
 
 #[derive(PartialEq, Eq, Copy, Clone)]
@@ -84,13 +85,15 @@ impl StriputaryGui {
 
     fn get_cut_info(&self, collection: &ExcerptCollection) -> Vec<CutInfo> {
         let mut cut_info: Vec<CutInfo> = vec![];
-        for (plot_start, plot_end) in self.plots.iter().zip(self.plots[1..].iter()) {
+        for (i, (plot_start, plot_end)) in self.plots.iter().zip(self.plots[1..].iter()).enumerate()
+        {
             let song = plot_start.excerpt.song_after.as_ref().unwrap();
             cut_info.push(CutInfo::new(
                 &collection.session,
                 song.clone(),
                 plot_start.cut_time,
                 plot_end.cut_time,
+                i,
             ));
         }
         cut_info
@@ -380,7 +383,7 @@ fn add_plot_label(ui: &mut Ui, song: Option<&Song>, finished_cutting: bool) {
     let color = get_label_color(finished_cutting);
     if let Some(ref song) = song {
         ui.add(Label::new(
-            RichText::new(format!("{}", song.title)).color(color),
+            RichText::new(format_title(&song.title)).color(color),
         ));
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -27,6 +27,7 @@ use self::plot::ExcerptPlot;
 use crate::audio_time::AudioTime;
 use crate::cut::CutInfo;
 use crate::excerpt_collection::ExcerptCollection;
+use crate::get_service_name;
 use crate::gui::session_manager::SessionIdentifier;
 use crate::gui::session_manager::SessionManager;
 use crate::recording::recording_thread_handle_status::RecordingThreadHandleStatus;
@@ -40,7 +41,7 @@ struct SongIdentifier {
 }
 
 pub struct StriputaryGui {
-    service_config: ServiceConfig,
+    service_name: Option<String>,
     collection: Option<ExcerptCollection>,
     plots: Vec<ExcerptPlot>,
     scroll_position: usize,
@@ -53,10 +54,10 @@ pub struct StriputaryGui {
 }
 
 impl StriputaryGui {
-    pub fn new(dir: &Path, service_config: ServiceConfig) -> Self {
+    pub fn new(dir: &Path, service_name: Option<String>) -> Self {
         let session_manager = SessionManager::new(dir);
         let mut gui = Self {
-            service_config,
+            service_name,
             collection: None,
             plots: vec![],
             scroll_position: 0,
@@ -129,9 +130,11 @@ impl StriputaryGui {
     }
 
     fn get_run_args(&self) -> Option<RunArgs> {
+        let service_config =
+            ServiceConfig::from_service_name(&get_service_name(&self.service_name)).unwrap();
         Some(RunArgs {
             session_dir: self.session_manager.get_currently_selected()?,
-            service_config: self.service_config.clone(),
+            service_config: service_config.clone(),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use anyhow::Result;
 use args::Opts;
 use clap::Parser;
 use config_file::ConfigFile;
-use service_config::ServiceConfig;
 
 use crate::gui::StriputaryGui;
 
@@ -31,10 +30,9 @@ fn main() -> Result<(), anyhow::Error> {
     let output_dir = args
         .output_dir
         .or(config_file.ok().map(|file| file.output_dir));
-    let service_config = ServiceConfig::from_service_name(&get_service_name(&args.service_name))?;
     match output_dir {
         Some(dir) => {
-            Ok(run_gui(&dir, service_config))
+            Ok(run_gui(&dir, args.service_name))
         }
         None => panic!("Need an output folder - either pass it as a command line argument or specify it in the config file (probably ~/.config/striputary/config.yaml")
     }
@@ -44,8 +42,8 @@ fn get_service_name(service_name: &Option<String>) -> &str {
     service_name.as_deref().unwrap_or(config::DEFAULT_SERVICE)
 }
 
-fn run_gui(dir: &Path, service_config: ServiceConfig) {
-    let app = StriputaryGui::new(dir, service_config);
+fn run_gui(dir: &Path, service_name: Option<String>) {
+    let app = StriputaryGui::new(dir, service_name);
     let native_options = eframe::NativeOptions::default();
     eframe::run_native("striputary", native_options, Box::new(|_| Box::new(app)));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,29 +21,39 @@ use anyhow::Result;
 use args::Opts;
 use clap::Parser;
 use config_file::ConfigFile;
+use service_config::Service;
 
 use crate::gui::StriputaryGui;
 
 fn main() -> Result<(), anyhow::Error> {
     let args = Opts::parse();
     let config_file = ConfigFile::read();
+    if let Err(ref e) = config_file {
+        println!("{}", e);
+    }
+    let config_file = config_file.ok();
     let output_dir = args
         .output_dir
-        .or(config_file.ok().map(|file| file.output_dir));
+        .or(config_file.as_ref().map(|file| file.output_dir.clone()));
+    let service = args
+        .service
+        .or(config_file.and_then(|file: ConfigFile| file.service))
+        .unwrap_or_else(|| {
+            let service = Service::default();
+            println!("No service specified in command line args or config file. Using default.");
+            service
+        });
+    println!("Using service: {}", service);
     match output_dir {
         Some(dir) => {
-            Ok(run_gui(&dir, args.service_name))
+            Ok(run_gui(&dir, service))
         }
         None => panic!("Need an output folder - either pass it as a command line argument or specify it in the config file (probably ~/.config/striputary/config.yaml")
     }
 }
 
-fn get_service_name(service_name: &Option<String>) -> &str {
-    service_name.as_deref().unwrap_or(config::DEFAULT_SERVICE)
-}
-
-fn run_gui(dir: &Path, service_name: Option<String>) {
-    let app = StriputaryGui::new(dir, service_name);
+fn run_gui(dir: &Path, service: Service) {
+    let app = StriputaryGui::new(dir, service);
     let native_options = eframe::NativeOptions::default();
     eframe::run_native("striputary", native_options, Box::new(|_| Box::new(app)));
 }

--- a/src/recording/dbus.rs
+++ b/src/recording/dbus.rs
@@ -76,7 +76,17 @@ fn is_playback_stopped(properties: &PC) -> bool {
 }
 
 fn get_song_length(metadata: &MetadataDict) -> f64 {
-    (metadata["mpris:length"].as_u64().unwrap() as f64) * 1e-6
+    let val = &metadata["mpris:length"];
+    let length_microseconds = val
+        .as_u64()
+        .or(val.as_i64().map(|x| x as u64))
+        .unwrap_or_else(|| {
+            val.as_str()
+                .expect("Failed to parse song length as string")
+                .parse()
+                .expect("Failed to parse song length string as integer")
+        });
+    (length_microseconds as f64) * 1e-6
 }
 
 fn get_song_from_dbus_properties(properties: PC) -> Option<Song> {

--- a/src/recording/dbus.rs
+++ b/src/recording/dbus.rs
@@ -168,6 +168,10 @@ pub fn previous_song(service_config: &ServiceConfig) -> Result<()> {
     dbus_set_playback_status_command(service_config, "Previous")
 }
 
+pub fn next_song(service_config: &ServiceConfig) -> Result<()> {
+    dbus_set_playback_status_command(service_config, "Next")
+}
+
 pub fn start_playback(service_config: &ServiceConfig) -> Result<()> {
     dbus_set_playback_status_command(service_config, "Play")
 }

--- a/src/recording/mod.rs
+++ b/src/recording/mod.rs
@@ -1,4 +1,4 @@
-mod dbus;
+pub mod dbus;
 mod recorder;
 mod recording_status;
 mod recording_thread;

--- a/src/recording/recorder.rs
+++ b/src/recording/recorder.rs
@@ -101,11 +101,6 @@ fn get_sink_input_index(service_config: &ServiceConfig) -> Result<Option<i32>> {
     temp.next()
         .map(|capture| get_sink_index_from_pacmd_output_capture(&capture))
         .transpose()
-    // for capture in captures {
-    //     if sink_source_name == SINK_SOURCE_NAME {
-    //         ;
-    //     }
-    // }
 }
 
 fn get_sink_index_from_pacmd_output_capture(capture: &Captures) -> Result<i32> {

--- a/src/recording/recorder.rs
+++ b/src/recording/recorder.rs
@@ -46,7 +46,10 @@ fn setup_recording(service_config: &ServiceConfig) -> Result<()> {
     let mb_index = get_sink_input_index(service_config)?;
     match mb_index {
         Some(index) => redirect_sink(index).map(|_| ()),
-        None => Err(anyhow!("Failed to find sink index")),
+        None => Err(anyhow!(
+            "Failed to find sink index for service: {}",
+            service_config.sink_name
+        )),
     }
 }
 

--- a/src/recording/recording_status.rs
+++ b/src/recording/recording_status.rs
@@ -2,6 +2,7 @@
 pub enum RecordingExitStatus {
     FinishedOrInterrupted,
     AlbumFinished,
+    NoNewSongForTooLong,
 }
 
 #[derive(PartialEq)]

--- a/src/recording/recording_thread.rs
+++ b/src/recording/recording_thread.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::Ordering;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 use std::thread::{self};
-use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::anyhow;
@@ -91,11 +90,11 @@ impl RecordingThread {
         // pulse audio sink. Also it avoids overflows when calculating the offset
         println!("Begin pre-session phase");
         start_playback(&self.run_args.service_config)?;
-        thread::sleep(Duration::from_secs_f64(TIME_BEFORE_SESSION_START));
+        thread::sleep(TIME_BEFORE_SESSION_START);
         stop_playback(&self.run_args.service_config)?;
         println!("Go to beginning of song");
         previous_song(&self.run_args.service_config)?;
-        thread::sleep(Duration::from_secs_f64(WAIT_TIME_BEFORE_FIRST_SONG));
+        thread::sleep(WAIT_TIME_BEFORE_FIRST_SONG);
         Ok(())
     }
 
@@ -143,6 +142,6 @@ impl RecordingThread {
 
     fn final_buffer_phase(&self) {
         println!("Recording finished. Record final buffer for a few seconds");
-        thread::sleep(Duration::from_secs_f64(TIME_AFTER_SESSION_END));
+        thread::sleep(TIME_AFTER_SESSION_END);
     }
 }

--- a/src/recording/recording_thread.rs
+++ b/src/recording/recording_thread.rs
@@ -20,7 +20,9 @@ use super::recording_status::RecordingExitStatus;
 use crate::config;
 use crate::config::TIME_AFTER_SESSION_END;
 use crate::config::TIME_BEFORE_SESSION_START;
+use crate::config::TIME_BETWEEN_SUBSEQUENT_DBUS_COMMANDS;
 use crate::config::WAIT_TIME_BEFORE_FIRST_SONG;
+use crate::recording::dbus::next_song;
 use crate::recording::recorder;
 use crate::recording::recording_status::RecordingStatus;
 use crate::recording_session::RecordingSession;
@@ -79,6 +81,11 @@ impl RecordingThread {
     }
 
     fn initial_buffer_phase(&self) -> Result<()> {
+        // Go to next song and back. This helps with missing metadata
+        // for the first track in some configurations.
+        next_song(&self.run_args.service_config)?;
+        thread::sleep(TIME_BETWEEN_SUBSEQUENT_DBUS_COMMANDS);
+        previous_song(&self.run_args.service_config)?;
         // Add a small time buffer before starting the playback properly.
         // This ensures that something starts playing, thus registering the
         // pulse audio sink. Also it avoids overflows when calculating the offset

--- a/src/recording/recording_thread.rs
+++ b/src/recording/recording_thread.rs
@@ -42,6 +42,12 @@ impl RecordingThread {
     }
 
     pub fn record_new_session(&self) -> Result<(RecordingExitStatus, RecordingSession)> {
+        let result = self.internal_record_new_session();
+        self.is_running.store(false, Ordering::SeqCst);
+        result
+    }
+
+    fn internal_record_new_session(&self) -> Result<(RecordingExitStatus, RecordingSession)> {
         create_dir_all(&self.run_args.session_dir).context("Failed to create session directory")?;
         if self.run_args.get_buffer_file().exists() {
             return Err(anyhow!(
@@ -57,7 +63,6 @@ impl RecordingThread {
             self.polling_loop(&self.run_args.get_yaml_file(), &record_start_time)?;
         recorder::stop_recording(recording_handles)?;
         session.save()?;
-        self.is_running.store(false, Ordering::SeqCst);
         Ok((status, session))
     }
 

--- a/src/service_config.rs
+++ b/src/service_config.rs
@@ -1,7 +1,37 @@
-use anyhow::anyhow;
+use std::fmt::Display;
+use std::str::FromStr;
+
 use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::recording::dbus::get_instance_of_service;
+
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Service {
+    #[default]
+    SpotifyNative,
+    SpotifyChromium,
+}
+
+impl FromStr for Service {
+    type Err = serde_yaml::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // This is quite ugly, but ensures that the config file string representation
+        // is the same as in the command line args (which uses the FromStr impl),
+        // without adding any additional dependencies
+        serde_yaml::from_str(s)
+    }
+}
+
+impl Display for Service {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Similar to the from_str implementation, this is ugly but consistent.
+        write!(f, "{}", serde_yaml::to_string(self).unwrap())
+    }
+}
 
 #[derive(Clone)]
 pub struct ServiceConfig {
@@ -10,17 +40,17 @@ pub struct ServiceConfig {
 }
 
 impl ServiceConfig {
-    pub fn from_service_name(service_name: &str) -> Result<ServiceConfig> {
-        let config = match service_name {
-            "spotify" => Ok(ServiceConfig {
+    pub fn from_service(service: Service) -> Result<ServiceConfig> {
+        use Service::*;
+        let config = match service {
+            SpotifyNative => Ok(ServiceConfig {
                 sink_name: "Spotify".to_string(),
                 dbus_bus_name: "org.mpris.MediaPlayer2.spotify".to_string(),
             }),
-            "spotify-chromium" => Ok(ServiceConfig {
+            SpotifyChromium => Ok(ServiceConfig {
                 sink_name: "Playback".to_string(),
                 dbus_bus_name: get_instance_of_service("org.mpris.MediaPlayer2.chromium")?,
             }),
-            _ => Err(anyhow!("Unknown service name: {}", service_name)),
         };
         config
     }

--- a/src/service_config.rs
+++ b/src/service_config.rs
@@ -1,6 +1,8 @@
 use anyhow::anyhow;
 use anyhow::Result;
 
+use crate::recording::dbus::get_instance_of_service;
+
 #[derive(Clone)]
 pub struct ServiceConfig {
     pub sink_name: String,
@@ -9,12 +11,17 @@ pub struct ServiceConfig {
 
 impl ServiceConfig {
     pub fn from_service_name(service_name: &str) -> Result<ServiceConfig> {
-        match service_name {
+        let config = match service_name {
             "spotify" => Ok(ServiceConfig {
                 sink_name: "Spotify".to_string(),
                 dbus_bus_name: "org.mpris.MediaPlayer2.spotify".to_string(),
             }),
+            "spotify-chromium" => Ok(ServiceConfig {
+                sink_name: "Playback".to_string(),
+                dbus_bus_name: get_instance_of_service("org.mpris.MediaPlayer2.chromium")?,
+            }),
             _ => Err(anyhow!("Unknown service name: {}", service_name)),
-        }
+        };
+        config
     }
 }

--- a/src/song.rs
+++ b/src/song.rs
@@ -57,6 +57,7 @@ fn sanitize_string(s: &str) -> String {
 fn sanitize_or_default(s: &Option<String>, default: &str) -> String {
     s.as_ref()
         .map(|s| sanitize_string(s))
+        .filter(|s| s != "")
         .unwrap_or(default.into())
 }
 

--- a/src/song.rs
+++ b/src/song.rs
@@ -7,32 +7,28 @@ use serde::Serialize;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Song {
-    pub artist: String,
-    pub album: String,
-    pub title: String,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub title: Option<String>,
     pub track_number: Option<i64>,
     pub length: f64,
 }
 
 impl Song {
-    pub fn get_target_file(&self, music_dir: &Path) -> PathBuf {
+    pub fn get_target_file(&self, music_dir: &Path, num_in_recording: usize) -> PathBuf {
         let track_number_str = if let Some(track_number) = self.track_number {
             format!("{:02}", track_number)
         } else {
-            "".into()
+            format!("recording_{}", num_in_recording)
         };
-        let file_name = format!(
-            "{}_{}.opus",
-            track_number_str,
-            &sanitize_string(&self.title)
-        );
+        let file_name = format!("{}_{}.opus", track_number_str, format_title(&self.title),);
         self.get_album_folder(music_dir).join(Path::new(&file_name))
     }
 
     pub fn get_album_folder(&self, music_dir: &Path) -> PathBuf {
         music_dir
-            .join(Path::new(&sanitize_string(&self.artist)))
-            .join(Path::new(&sanitize_string(&self.album)))
+            .join(Path::new(&format_artist(&self.artist)))
+            .join(Path::new(&format_album(&self.album)))
     }
 }
 
@@ -41,14 +37,37 @@ impl fmt::Display for Song {
         write!(
             f,
             "{} - {} - {} ({}s)",
-            self.artist,
-            self.album,
-            self.title,
+            format_artist(&self.artist),
+            format_album(&self.album),
+            format_title(&self.title),
             self.length.round()
         )
     }
 }
 
 fn sanitize_string(s: &str) -> String {
-    s.replace("/", "").replace(" ", "")
+    let first_item = if s.contains(",") {
+        s.split(",").next().unwrap()
+    } else {
+        s
+    };
+    first_item.replace("/", "").replace(" ", "")
+}
+
+fn sanitize_or_default(s: &Option<String>, default: &str) -> String {
+    s.as_ref()
+        .map(|s| sanitize_string(s))
+        .unwrap_or(default.into())
+}
+
+pub fn format_title(title: &Option<String>) -> String {
+    sanitize_or_default(title, "unknown_title")
+}
+
+pub fn format_album(album: &Option<String>) -> String {
+    sanitize_or_default(album, "unknown_album")
+}
+
+pub fn format_artist(artist: &Option<String>) -> String {
+    sanitize_or_default(artist, "unknown_artist")
 }

--- a/src/song.rs
+++ b/src/song.rs
@@ -10,15 +10,20 @@ pub struct Song {
     pub artist: String,
     pub album: String,
     pub title: String,
-    pub track_number: i64,
+    pub track_number: Option<i64>,
     pub length: f64,
 }
 
 impl Song {
     pub fn get_target_file(&self, music_dir: &Path) -> PathBuf {
+        let track_number_str = if let Some(track_number) = self.track_number {
+            format!("{:02}", track_number)
+        } else {
+            "".into()
+        };
         let file_name = format!(
-            "{:02}_{}.opus",
-            self.track_number,
+            "{}_{}.opus",
+            track_number_str,
             &sanitize_string(&self.title)
         );
         self.get_album_folder(music_dir).join(Path::new(&file_name))


### PR DESCRIPTION
Basic support for spotify-chromium.
- Add service config for spotify chromium
- Automatically determine instance ID for MPRIS
- Handle missing metadata (which happens a lot in chromium) more gracefully (closes #5)
- Stop recording if too much time elapses after the last song
- Go to next and previous song before recording, which helps with some missing metadata.
- Add better support for specifying the used service. Allow reading service from the config file

Closes #7 